### PR TITLE
chore: fix typo

### DIFF
--- a/sections/contact.html
+++ b/sections/contact.html
@@ -10,7 +10,10 @@
                     <i class="fas fa-map-marker-alt"></i>
                     <div>
                         <h3>Location</h3>
-                        <p>Mezzanine floor - 3 salis Tower, besides ADCOOP / FAB, Corniche Road, Abu Dhabi, UAE</p>
+                        <p>
+                            Mezzanine floor - 3 Sails Tower, besides ADCOOP /
+                            FAB, Corniche Road, Abu Dhabi, UAE
+                        </p>
                     </div>
                 </div>
                 <div class="info-item">


### PR DESCRIPTION
Fix the very unprofessional typo in the name of the building containing this prestigious gymnasium.